### PR TITLE
Efficient prefixes

### DIFF
--- a/src/ews.erl
+++ b/src/ews.erl
@@ -9,6 +9,7 @@
          get_service_op_info/2, get_service_op_info/3,
          call_service_op/4, call_service_op/5, call_service_op/6,
          encode_service_op/4, encode_service_op/5, encode_service_op/6,
+         serialize_service_op/5,
          encode_service_op_faults/6,
          encode_service_op_result/5,
          decode_service_op_result/3, decode_service_op_result/4,
@@ -103,6 +104,9 @@ encode_service_op(Model, Service, Op, Header, Body) when is_atom(Model) ->
     ews_svc:encode(Model, Service, Op, Header, Body, #{}).
 encode_service_op(Model, Service, Op, Header, Body, Opts) when is_atom(Model) ->
     ews_svc:encode(Model, Service, Op, Header, Body, Opts).
+
+serialize_service_op(Model, Service, Op, Header, Body) when is_atom(Model) ->
+    ews_svc:serialize(Model, Service, Op, Header, Body).
 
 encode_service_op_result(Model, Service, Op, Header, Body) when is_atom(Model) ->
     ews_svc:encode_out(Model, Service, Op, Header, Body, #{}).

--- a/src/ews.hrl
+++ b/src/ews.hrl
@@ -55,3 +55,5 @@
 -define(log(Expression), ok).
 -define(log(Format, Arguments), ok).
 -endif.
+
+-define(XML_HDR, <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>">>).

--- a/src/ews_soap.erl
+++ b/src/ews_soap.erl
@@ -8,7 +8,6 @@
         ]).
 
 -define(SOAPNS, "http://schemas.xmlsoap.org/soap/envelope/").
--define(XML_HDR, <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>">>).
 
 -include("ews.hrl").
 

--- a/src/ews_svc.erl
+++ b/src/ews_svc.erl
@@ -150,9 +150,10 @@ serialize(ModelRef, ServiceName, OpName, HeaderParts, BodyParts) ->
         {error, Error} ->
             {error, Error};
         {ok, Info} ->
-            {ok, {EncodedHeader, EncodedBody}} =
+            {ok, {Header, Body}} =
                 encode_service_ins(HeaderParts, BodyParts, Info, Model),
-            {ok, {EncodedHeader, EncodedBody}}
+            Envelope = ews_soap:make_envelope(Header, Body),
+            [?XML_HDR, ews_xml:encode(Envelope)]
     end.
 
 encode_out(ModelRef, ServiceName, OpName, HeaderParts, BodyParts, _Opts) ->

--- a/src/ews_svc.erl
+++ b/src/ews_svc.erl
@@ -18,6 +18,7 @@
          get_model/1, get_service_models/1,
          list_simple_clashes/1, list_full_clashes/1, emit_model/2,
          call/5, call/6, encode/5, encode/6,
+         serialize/5,
          encode_out/6,
          encode_faults/6,
          decode/4, decode/5,
@@ -142,6 +143,17 @@ encode(ModelRef, ServiceName, OpName, HeaderParts, BodyParts, _Opts) ->
     Model = gen_server:call(?MODULE, {get_model, ModelRef}),
     encode_service_op(ModelRef, Model, ServiceName, OpName,
                       HeaderParts, BodyParts).
+
+serialize(ModelRef, ServiceName, OpName, HeaderParts, BodyParts) ->
+    Model = gen_server:call(?MODULE, {get_model, ModelRef}),
+    case get_op_message_details(ModelRef, ServiceName, OpName) of
+        {error, Error} ->
+            {error, Error};
+        {ok, Info} ->
+            {ok, {EncodedHeader, EncodedBody}} =
+                encode_service_ins(HeaderParts, BodyParts, Info, Model),
+            {ok, {EncodedHeader, EncodedBody}}
+    end.
 
 encode_out(ModelRef, ServiceName, OpName, HeaderParts, BodyParts, _Opts) ->
     Model = gen_server:call(?MODULE, {get_model, ModelRef}),


### PR DESCRIPTION
Factor the xmlns declaration at the first occurrence of the tag so we send smaller queries from EWS