### PR TITLE
[UP-1145] fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   compile-deps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -34,7 +34,7 @@ jobs:
 
   compile:
     needs: [compile-deps]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -66,7 +66,7 @@ jobs:
 
   xref:
     needs: [compile]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -90,7 +90,7 @@ jobs:
 
   ct:
     needs: [compile]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -114,7 +114,7 @@ jobs:
 
   eunit:
     needs: [compile]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -138,7 +138,7 @@ jobs:
 
   dialyzer:
     needs: [compile]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
The CI was running unbuntu-20.04, that doesn't exist anymore. This uses 24.04 instead so we can run CI again.

https://kivra.atlassian.net/browse/UP-1145
