### PR TITLE
[UP-1270] support include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ ct:
 
 xref:
 	rebar3 xref
+
+repl:
+	rebar3 as test shell

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ ews is a library for interacting with SOAP web services. It includes functionali
 * Support for `include` in schemas.
 * Handle non-ASCII in types
 * Fix for a bug that didn't decode emtpy records like `-record(foo, {}).`
+* Handle `group`.
+* Handle `simpleContent` with attributes by creating a record for it.
 
 ## Changes between 3.1.0 and 4.0.0
 
@@ -55,6 +57,17 @@ rendered XML instead of the internal ews representation.
 Version 3.0.0 introduces an extra field called `__attrs` first of record
 where the XSD defines attributes. `__attrs` is a map and keys should be
 atoms.
+
+### New simpleContent with attributes support
+
+Version 4.1.0 introduces new logic for simpleContent with attributes.
+Normally we don't emit records for simpleContent, but if the simpleContent
+has attributes we have to. Since the simpleContent isn't an element we
+don't have a name for the field in the record so it will get the special
+name `value`. Example:
+
+    -record(foo, {'__attrs' :: #{bar => string() | binary()} | undefined
+                  value :: integer() | undefined}).
 
 ## Interface
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ deserialize all possible ins, outs and faults of all ops the the selected model.
 It will generate defaults for every entry in every record that can be reached.
 A possible ct test would look like this:
 
-`serialize_deserialize(_Config) ->
-    {ok, _} = ews:add_wsdl_to_model(moose,
-                                    "moose.wsdl")),
-    ok = ews_test:test_everything(moose),
-    ok.`
+    serialize_deserialize(_Config) ->
+        {ok, _} = ews:add_wsdl_to_model(moose,
+                                        "moose.wsdl")),
+        ok = ews_test:test_everything(moose),
+        ok.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,23 @@ ews is a library for interacting with SOAP web services. It includes functionali
 * call web service operations with automatic encoding of operands and decoding of the response
 * supply hooks that are applied immediately before or after the actual SOAP calls
 
+## Changes between 4.0.0 and 4.1.0
+
+* Support for `include` in schemas.
+* Handle non-ASCII in types
+* Fix for a bug that didn't decode emtpy records like `-record(foo, {}).`
+
 ## Changes between 3.1.0 and 4.0.0
 
-* Breaking changes
+Breaking changes
 
 * `ews:call_service_op` will now return `{ok, [term()]}` instead of `{ok, term()}`, cause there can actually  be more than one message returned.
 * `ews:decode_in` will not return `{ok, {Svc, Op, list(Headers), list(Body)}}`
+
+Other changes
+
+* Non-optional attributes in `__attrs` will now have `:=` in their typespec
+* A more consistent ordering of records. First in dep order, then namespace and lastly name. This will reorder everything once now, but less in the future.
 
 ## Changes between 3.0.1 and 3.1.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,10 @@
 
 {profiles,
  [{test,
-   [{deps, [{meck, "0.8.8"}]},
+   [{deps, [ {meck, "0.8.8"}
+           , {redbug, {git, "git@github.com:massemanet/redbug.git",
+                       {tag,"2.0.10"}}}
+           ]},
     {ct_opts, [
                {ct_hooks, [
                            cth_surefire,

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %%-*- mode: erlang -*-
 
 {deps, [
-        {hackney, {git, "git@github.com:benoitc/hackney.git", {tag, "1.17.4"}}}
+        {hackney, {git, "git@github.com:benoitc/hackney.git", {tag, "1.25.0"}}}
        ]}.
 
 {erl_opts, [debug_info]}.

--- a/src/ews.hrl
+++ b/src/ews.hrl
@@ -43,6 +43,8 @@
 -record(simple_content, {name, order, restrictions, attrs=[]}).
 -record(attribute, {name, base, type, use, default, fixed}).
 -record(complex_type, {name, extends, abstract, restrictions, parts, attrs=[]}).
+-record(group, {name, parts}).
+-record(group_ref, {ref, min_occurs=1, max_occurs=1}).
 -record(reference, {name}).
 
 -record(restriction, {base_type, values}).

--- a/src/ews.hrl
+++ b/src/ews.hrl
@@ -44,7 +44,7 @@
 -record(attribute, {name, base, type, use, default, fixed}).
 -record(complex_type, {name, extends, abstract, restrictions, parts, attrs=[]}).
 -record(group, {name, parts}).
--record(group_ref, {ref, min_occurs=1, max_occurs=1}).
+-record(group_ref, {ref, min_occurs, max_occurs}).
 -record(reference, {name}).
 
 -record(restriction, {base_type, values}).

--- a/src/ews.hrl
+++ b/src/ews.hrl
@@ -40,7 +40,8 @@
 -record(element, {name, type, default, fixed, nillable=false,
                   min_occurs=1, max_occurs=1, parts, attrs=[]}).
 -record(simple_type, {name, order, restrictions}).
--record(attribute, {name, type, use, default, fixed}).
+-record(simple_content, {name, order, restrictions, attrs=[]}).
+-record(attribute, {name, base, type, use, default, fixed}).
 -record(complex_type, {name, extends, abstract, restrictions, parts, attrs=[]}).
 -record(reference, {name}).
 
@@ -57,6 +58,7 @@
 -record(base, {xsd_type, erl_type, restrictions, list=false, union=false}).
 -record(enum, {type, values, list=false, union=false}).
 -record(meta, {nillable=false, default, fixed, max, min}).
+-record(sc, {qname, type, meta, attrs=[]}).
 
 %% Macro definitions
 -ifdef(DEBUG).

--- a/src/ews_emit.erl
+++ b/src/ews_emit.erl
@@ -39,7 +39,7 @@ model_to_file(#model{type_map=Tbl, simple_types=Ts}, Filename, ModelRef) ->
     file:close(Fd).
 
 output_typedef(#type{alias=Alias}) ->
-    ["-type '#", atom_to_list(Alias), "'() :: tuple().  "
+    ["-type '#", utf8_atom_to_list(Alias), "'() :: tuple().  "
      "%% Needed due to circular type definition\n"].
 
 output_type(#type{qname=Qname, alias=Alias, attrs=[]}, Tbl, ModelRef, Unresolved) ->
@@ -142,11 +142,11 @@ record_spec(T, Unresolved) ->
         false ->
             ["#", tick_word(T), "{}"];
         true ->
-            ["'#", atom_to_list(T), "'()"]
+            ["'#", utf8_atom_to_list(T), "'()"]
     end.
 
 tick_word(Word) when is_atom(Word) ->
-    tick_word(atom_to_list(Word));
+    tick_word(utf8_atom_to_list(Word));
 tick_word(Word) ->
     case erl_scan:string(Word) of
         {ok, [{atom, _, _}], _} ->
@@ -251,3 +251,7 @@ erl_type({_,_} = T) ->
 erl_type(T) ->
     #base{erl_type = ET} = ews_xsd:to_base({"no_ns", T}),
     output_erl_type(ET).
+
+%% This outputs an atom as an utf8 string.
+utf8_atom_to_list(Atom) ->
+    binary_to_list(atom_to_binary(Atom)).

--- a/src/ews_emit.erl
+++ b/src/ews_emit.erl
@@ -146,13 +146,18 @@ record_spec(T, Unresolved) ->
     end.
 
 tick_word(Word) when is_atom(Word) ->
-    tick_word(utf8_atom_to_list(Word));
-tick_word(Word) ->
-    case erl_scan:string(Word) of
+    do_tick_word(utf8_atom_to_list(Word));
+tick_word(Word) when is_list(Word) ->
+    do_tick_word(
+      binary_to_list(
+        unicode:characters_to_binary(Word, unicode, utf8))).
+
+do_tick_word(Utf8Word) ->
+    case erl_scan:string(Utf8Word) of
         {ok, [{atom, _, _}], _} ->
-            Word;
+            Utf8Word;
         _ ->
-            [$', Word, $']
+            [$', Utf8Word, $']
     end.
 
 check_nillable(Base, #meta{nillable = "true"}) ->

--- a/src/ews_emit.erl
+++ b/src/ews_emit.erl
@@ -51,17 +51,24 @@ output_type(#type{qname=Qname, alias=Alias, attrs=[]}, Tbl, ModelRef, Unresolved
     [Line1, string:join(PartRows, JoinStr), "}).\n"];
 output_type(#type{qname=Qname, alias=Alias, attrs=Attrs}, Tbl, ModelRef,
             Unresolved) ->
+    %% logger:notice("Tp: ~tp~n", [Tp]),
     Line0 = "%% @doc Possible keys for '__attrs'\n",
-    AttrDocs = [ ["%% ", tick_word(A), " :: ", no_ns(T), "\n"] ||
-                   #attribute{name={_,A},type=T} <- Attrs ],
+    AttrDocs = [ ["%% ", tick_word(no_ns(A)), " :: ", no_ns(T), "\n"] ||
+                   #attribute{name=A,type=T} <- Attrs ],
     Line1 = ["-record(", tick_word(Alias), ", {"],
     Indent = iolist_size(Line1),
     Attr = ["'__attrs' :: #{"],
     AttrIndent = Indent + iolist_size(Attr),
     AttrEnd = output_attr_undefined(Attrs),
-    AttrRows = [lists:flatten([tick_word(A), output_map_default(U),
-                               erl_type(T)]) ||
-                   #attribute{name={_,A},use=U,type=T} <- Attrs],
+    AttrRows = [lists:flatten([tick_word(no_ns(A)), output_map_default(U),
+                               output_single_type( B
+                                                 , #meta{max=1}
+                                                 , AttrIndent
+                                                 , Tbl
+                                                 , ModelRef
+                                                 , Unresolved
+                                                 )]) ||
+                   #attribute{name=A,use=U,base=B} <- Attrs],
     JoinAttrs = ",\n"++lists:duplicate(AttrIndent, $ ),
     AttrStr = lists:flatten([Attr, string:join(AttrRows, JoinAttrs), AttrEnd]),
     PartRows = [output_part(P, Indent, Tbl, ModelRef, Unresolved) ||
@@ -71,6 +78,14 @@ output_type(#type{qname=Qname, alias=Alias, attrs=Attrs}, Tbl, ModelRef,
                                          JoinStr), "}).\n"].
 
 output_part(#elem{qname=Qname, type=T, meta=M}, Indent, Tbl,
+            ModelRef, Unresolved) ->
+    A = ews_alias:create(Qname),
+    #meta{min=Min} = M,
+    Base = [tick_word(A), " :: "],
+    SpecIndent = Indent + iolist_size(Base),
+    Ts = output_types(T, M, SpecIndent, Tbl, ModelRef, Unresolved),
+    check_min(check_nillable([Base, Ts], M), Min);
+output_part(#sc{qname=Qname, type=T, meta=M}, Indent, Tbl,
             ModelRef, Unresolved) ->
     A = ews_alias:create(Qname),
     #meta{min=Min} = M,
@@ -249,13 +264,6 @@ emit_enum(Values, Indent) ->
 
 no_ns({_NS, N}) -> N;
 no_ns(N) -> N.
-
-erl_type({_,_} = T) ->
-    #base{erl_type = ET} = ews_xsd:to_base(T),
-    output_erl_type(ET);
-erl_type(T) ->
-    #base{erl_type = ET} = ews_xsd:to_base({"no_ns", T}),
-    output_erl_type(ET).
 
 %% This outputs an atom as an utf8 string.
 utf8_atom_to_list(Atom) ->

--- a/src/ews_model.erl
+++ b/src/ews_model.erl
@@ -22,6 +22,9 @@
          get_from_base/2, get_from_alias/2, get_super/2, get_subs/2,
          keys/1, values/1, elem_keys/1, elem_values/1,
          is_root/2, append_model/3]).
+-export([ put_group/3
+        , get_group/3
+        ]).
 
 -include("ews.hrl").
 -include_lib("ews/include/ews.hrl").
@@ -41,6 +44,9 @@ put(#elem{qname=Key} = E, _Model, Table) ->
 
 put_elem(#elem{qname=Key} = E, Parent, Table) ->
     ets:insert_new(Table, {{Key, Parent}, E}).
+
+put_group(#group{name=Key} = G, Model, Table) ->
+    ets:insert_new(Table, {{group, Model, Key}, G}).
 
 replace(#type{qname=Key} = Type, Table) ->
     ets:insert(Table, {Key, Type});
@@ -75,6 +81,14 @@ get_elem({_,_} = Key, Parent, Table) ->
             false;
         [[Elem]] ->
             Elem
+    end.
+
+get_group({_,_} = Key, Model, Table) ->
+    case ets:lookup(Table, {group, Model, Key}) of
+        [{{group, Model, Key}, Value}] ->
+            Value;
+        [] ->
+            false
     end.
 
 get_parts(Key, Table) ->

--- a/src/ews_model.erl
+++ b/src/ews_model.erl
@@ -253,6 +253,23 @@ merge_elem_lists(Elems1, Elems2) ->
                      Error ->
                          error({unmatched_element, Error, E1, Elems2}),
                          {error, {unmatched_element, E1, Elems2}}
+                 end;
+             (SC1 = #sc{qname = Qn1, meta = #meta{min = Min}}, {SCs, SC2s}) ->
+                 case lists:splitwith(fun (#sc{qname = Qn2}) ->
+                                              Qn2 /= Qn1
+                                      end, SC2s) of
+                     {H, [SC2 | T]} ->
+                         case merge_sc(SC1, SC2) of
+                             E = {error, _} ->
+                                 E;
+                             NewSC ->
+                                 {[NewSC | SCs], H ++ T}
+                         end;
+                     {_, []} when Min == 0 ->
+                         {[SC1 | SCs], SC2s};
+                     Error ->
+                         error({unmatched_element, Error, SC1, Elems2}),
+                         {error, {unmatched_element, SC1, Elems2}}
                  end
          end,
     case lists:foldl(MF, {[], Elems2}, Elems1) of
@@ -275,6 +292,12 @@ merge_elem(E1 = #elem{qname = Qn, type = T1, meta = M1},
            #elem{qname = Qn, type = T2, meta = M2}) ->
     E1#elem{type = combine_types(T1, T2), meta = combine_meta(M1, M2)};
 merge_elem(E1, E2) ->
+    {error, {incompatible_elements, E1, E2}}.
+
+merge_sc(E1 = #sc{qname = Qn, type = T1, meta = M1},
+           #sc{qname = Qn, type = T2, meta = M2}) ->
+    E1#sc{type = combine_types(T1, T2), meta = combine_meta(M1, M2)};
+merge_sc(E1, E2) ->
     {error, {incompatible_elements, E1, E2}}.
 
 combine_types(T, T) ->

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -164,8 +164,9 @@ encode_term(Term, #type{qname=Key, alias=A, attrs=[]}, Tbl) when is_tuple(Term) 
     end;
 encode_term(Term, #type{qname=Key, alias=A, attrs=[_|_]=PossAttrs}, Tbl)
   when is_tuple(Term) ->
-    logger:debug("PossAttrs: ~p~n", [PossAttrs]),
+    %% logger:notice("PossAttrs: ~p~n", [PossAttrs]),
     [Name, Attrs|Values] = tuple_to_list(Term), %% TODO: Move this one clause up
+    %% logger:notice("Attrs: ~p~n", [Attrs]),
     EncAttrs = encode_attributes(Attrs, PossAttrs, Key),
     Super = ews_model:get_super(Name, Tbl),
     case ews_model:get(Name, Tbl) of
@@ -189,6 +190,8 @@ encode_term(Term, #type{qname=Key, alias=A, attrs=[_|_]=PossAttrs}, Tbl)
     end;
 encode_term(Term, #type{qname={_, N}}, _) ->
     error({"expected #"++N++"{}", Term});
+encode_term(Term, #sc{type=Type}, Tbl) ->
+    encode_term(Term, Type, Tbl);
 encode_term(Term, #base{erl_type=Type, list=IsList}, _) ->
     case is_list(Term) of
         false ->
@@ -224,6 +227,8 @@ encode_attributes(undefined, _, _) ->
     [].
 
 do_encode_attributes([Attr | Tail], PossAttrs, Name, Acc) ->
+    %% logger:notice("encoding: PossAttrs: ~tp~nAttr: ~tp~nName: ~tp~n",
+    %%               [PossAttrs, Attr, Name]),
     EncAttr = encode_attr(PossAttrs, Attr, Name),
     do_encode_attributes(Tail, PossAttrs, Name, [EncAttr | Acc]);
 do_encode_attributes([], _, _, Acc) ->
@@ -231,10 +236,14 @@ do_encode_attributes([], _, _, Acc) ->
 
 encode_attr(Attrs, {Id, Value}, Name) when is_atom(Id) ->
     encode_attr(Attrs, {atom_to_list(Id), Value}, Name);
-encode_attr([#attribute{name = {_, Id}, type = Type} | _Tail],
+encode_attr([#attribute{name = {_, Id}, base = BaseType} | _Tail],
             {Id, Value}, _Name) ->
-    BaseType = erl_type(Type),
-    {Id, encode_single_base(Value, BaseType)};
+    [{txt, Enc}] = encode_term(Value, BaseType, noarg),
+    {Id, Enc};
+encode_attr([#attribute{name = Id, base = BaseType} | _Tail],
+            {Id, Value}, _Name) ->
+    [{txt, Enc}] = encode_term(Value, BaseType, noarg),
+    {Id, Enc};
 encode_attr([#attribute{name = _} | Tail], {Id, Value}, Name) ->
     encode_attr(Tail, {Id, Value}, Name);
 encode_attr([], {Id, _Value}, Name) ->
@@ -374,7 +383,8 @@ validate_xml({_, As, Cs}, #type{qname=Key, alias=Alias, attrs=[]}, Tbl) ->
             ValidatedXml =[ validate_xml(T, E, Tbl) || {T, E} <- Pairs ],
             list_to_tuple([Alias | ValidatedXml])
     end;
-validate_xml({_, As, Cs}, #type{qname=Key, alias=Alias, attrs=PossAttrs}, Tbl) ->
+validate_xml({_, As, Cs} = In,
+             #type{qname=Key, alias=Alias, attrs=PossAttrs}, Tbl) ->
     case is_nil(As) of
         true ->
             nil;
@@ -385,10 +395,20 @@ validate_xml({_, As, Cs}, #type{qname=Key, alias=Alias, attrs=PossAttrs}, Tbl) -
                         #type{qname=InheritedKey} ->
                             ews_model:get_parts(InheritedKey, Tbl)
                     end,
-            Pairs = match_children_elems(Cs, Elems, [], []),
-            ValidatedXml =[ validate_xml(T, E, Tbl) || {T, E} <- Pairs ],
-            Attrs = validate_attrs(As, PossAttrs, #{}),
-            list_to_tuple([Alias, Attrs | ValidatedXml])
+            case Elems of
+                %% Special case of a simpleContent with attributes
+                [#sc{type=BaseOrEnum}] ->
+                    %% logger:notice("decode PossAttrs: ~tp~nAs: ~tp~n",
+                    %%               [PossAttrs, As]),
+                    Sc = validate_xml(In, BaseOrEnum, Tbl),
+                    Attrs = validate_attrs(As, PossAttrs, #{}),
+                    list_to_tuple([Alias, Attrs, Sc]);
+                _ ->
+                    Pairs = match_children_elems(Cs, Elems, [], []),
+                    ValidatedXml =[ validate_xml(T, E, Tbl) || {T, E} <- Pairs ],
+                    Attrs = validate_attrs(As, PossAttrs, #{}),
+                    list_to_tuple([Alias, Attrs | ValidatedXml])
+            end
     end;
 validate_xml({_Qname, As, []}, #base{}, _) ->
     case is_nil(As) of
@@ -466,25 +486,38 @@ match_children_elems([], [], Acc, Res) ->
 validate_attrs([{?SCHEMA_INSTANCE_NS, _} | As], PossAttrs, Acc) ->
     validate_attrs(As, PossAttrs, Acc);
 validate_attrs([{Name, Value} | As], PossAttrs, Acc) ->
-    case [ P || #attribute{name = {_, N}} = P <- PossAttrs, N == Name ] of
-        [] ->
+    Attr =
+        case {[ P || #attribute{name = {_, N}} = P <- PossAttrs, N == Name ],
+              [ P || #attribute{name = N} = P <- PossAttrs, N == Name ]} of
+            {[], []} -> undefined;
+            {[#attribute{} = A], _} -> A;
+            {_, [#attribute{} = A]} -> A
+        end,
+    case Attr of
+        undefined ->
             logger:notice("Unexpected attribute: ~p~n", [Name]),
             validate_attrs(As, PossAttrs, Acc);
-        [#attribute{type = Type}] ->
-            %% TODO: how to we handle utf8 in both Name and Value?
+        #attribute{base = BaseOrEnum} ->
             %% By compiling with debug_info the typespec in the records should
             %% load all possible atoms.
-            QType = qname(Type),
-            #base{erl_type=ErlType} = ews_xsd:to_base(QType),
-            NameAtom = list_to_existing_atom(Name),
-            ValueBase = to_base(list_to_binary(Value), ErlType),
-            validate_attrs(As, PossAttrs, Acc#{NameAtom => ValueBase})
+            case BaseOrEnum of
+                #base{erl_type=ErlType} ->
+                    NameAtom = list_to_existing_atom(Name),
+                    ValueBase = to_base(list_to_binary(Value), ErlType),
+                    validate_attrs(As, PossAttrs, Acc#{NameAtom => ValueBase});
+                #enum{values=Vs} ->
+                    case lists:keyfind(Value, 2, Vs) of
+                        false ->
+                            error({"failed to convert enum", {Value, Vs}});
+                        {V, _} ->
+                            NameAtom = list_to_existing_atom(Name),
+                            validate_attrs(As, PossAttrs,
+                                           Acc#{NameAtom => V})
+                    end
+            end
     end;
 validate_attrs([], _, Acc) ->
     Acc.
-
-qname({_,_} = Qname) -> Qname;
-qname(Name) -> {"no_ns", Name}.
 
 to_base(Txt, string) when is_binary(Txt) -> Txt;
 to_base(Txt, string) when is_list(Txt) -> list_to_binary(Txt);
@@ -558,10 +591,3 @@ field_to_map(V, _M) ->
 
 field_names(Parts) ->
     [ews_alias:create(QN) || #elem{qname = QN} <- Parts].
-
-erl_type({_,_} = T) ->
-    #base{erl_type = ET} = ews_xsd:to_base(T),
-    ET;
-erl_type(T) ->
-    #base{erl_type = ET} = ews_xsd:to_base({"no_ns", T}),
-    ET.

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -339,7 +339,13 @@ validate_xml({_, [_|_] = As, []}, #type{qname=Key, alias=Alias,
             Attrs = validate_attrs(As, PossAttrs, #{}),
             list_to_tuple([Alias, Attrs | ValidatedXml])
     end;
-validate_xml({_, [], []}, #type{alias=Alias, elems=[]}, _Tbl) ->
+validate_xml({_, [], []}, #type{alias=Alias, elems=[], attrs=[_|_]}, _Tbl) ->
+    %% An element that should be empty, but with attributes
+    %% Should become an empty record like this:
+    %% -record(sausage, {'__attrs' :: #{a => binary()}}).
+    %% return `{sausage, undefined}`
+    {Alias, undefined};
+validate_xml({_, [], []}, #type{alias=Alias, elems=[], attrs=[]}, _Tbl) ->
     %% An element that should be empty.
     %% Should become an empty record like this:
     %% -record(sausage, {}).

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -339,6 +339,12 @@ validate_xml({_, [_|_] = As, []}, #type{qname=Key, alias=Alias,
             Attrs = validate_attrs(As, PossAttrs, #{}),
             list_to_tuple([Alias, Attrs | ValidatedXml])
     end;
+validate_xml({_, [], []}, #type{alias=Alias, elems=[]}, _Tbl) ->
+    %% An element that should be empty.
+    %% Should become an empty record like this:
+    %% -record(sausage, {}).
+    %% return `{sausage}`
+    {Alias};
 validate_xml({_, As, []}, #type{}, _Tbl) ->
     %% This is broken, an empty type that shouldn't be.
     case is_nil(As) of

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -202,16 +202,16 @@ encode_term(Term, #base{erl_type=Type, list=IsList}, _) ->
         true ->
             error({"expected non-list "++atom_to_list(Type), Term})
     end;
-encode_term(Term, #enum{values=Values, list=IsList}, _) ->
+encode_term(Term, #enum{values=Values, list=IsList, type=Type}, _) ->
     case is_list(Term) of
         true when IsList ->
-            ListParts = [ encode_single_enum(T, Values) || T <- Term ],
+            ListParts = [ encode_single_enum(T, Values, Type) || T <- Term ],
             [{txt, string:join(ListParts, " ")}];
         true ->
             Accept = string:join([ atom_to_list(A) || {A,_} <- Values ], " | "),
             error({"expected non-list "++Accept, Term});
         false ->
-            [{txt, encode_single_enum(Term, Values)}]
+            [{txt, encode_single_enum(Term, Values, Type)}]
     end.
 
 %% If the type had attributes we have to add them to the attributes
@@ -251,8 +251,10 @@ encode_attr([], {Id, _Value}, Name) ->
 
 encode_single_base(Term, BaseType) ->
     case BaseType of
-        string when is_binary(Term); is_list(Term) ->
+        string when is_binary(Term) ->
             Term;
+        string when is_list(Term) ->
+            unicode:characters_to_binary(Term, utf8);
         integer when is_integer(Term) ->
             integer_to_list(Term);
         float when is_float(Term) ->
@@ -263,13 +265,13 @@ encode_single_base(Term, BaseType) ->
             error({"expected "++atom_to_list(BaseType), Term})
     end.
 
-encode_single_enum(Term, Values) ->
+encode_single_enum(Term, Values, #base{erl_type=ErlType}) ->
     case lists:keyfind(Term, 1, Values) of
         false ->
             Accept = string:join([ atom_to_list(A) || {A,_} <- Values ], " | "),
             error({bad_term, Term, "expected one of: " ++ Accept});
         {Term, Value} ->
-            Value
+            encode_single_base(Value, ErlType)
     end.
 
 %% ---------------------------------------------------------------------------
@@ -520,7 +522,8 @@ validate_attrs([], _, Acc) ->
     Acc.
 
 to_base(Txt, string) when is_binary(Txt) -> Txt;
-to_base(Txt, string) when is_list(Txt) -> list_to_binary(Txt);
+to_base(Txt, string) when is_list(Txt) ->
+    unicode:characters_to_binary(Txt, unicode, utf8);
 to_base(Txt, integer) -> list_to_integer(binary_to_list(Txt));
 to_base(Txt, float) -> try_cast_float(binary_to_list(Txt));
 to_base(<<"true">>, boolean) -> true;

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -432,7 +432,7 @@ validate_xml({_Qname, As, []}, #enum{}, _) ->
             undefined
     end;
 validate_xml({_Qname, _, [{txt, Txt}]}, #enum{values=Vs}, _) ->
-    Str = binary_to_list(Txt),
+    Str = unicode:characters_to_list(Txt, utf8),
     case lists:keyfind(Str, 2, Vs) of
         false ->
             error({"failed to convert enum", {Txt, Vs}});

--- a/src/ews_test.erl
+++ b/src/ews_test.erl
@@ -154,25 +154,23 @@ def_elems([#sc{type = Qname, meta = Meta} | T], Tbl) ->
 def_elems([], _) ->
     [].
 
-def_attrs([#attribute{ name = {_, Name}, type = Type}| T], Acc) ->
+def_attrs([#attribute{name = {_, Name}, base = BaseOrEnum}| T], Acc) ->
     Key = list_to_atom(Name),
-    Value = def_erl(erl_type(Type)),
+    Value = erl_type(BaseOrEnum),
     def_attrs(T, Acc#{Key => Value});
-def_attrs([#attribute{ name = Name, type = Type}| T], Acc) ->
+def_attrs([#attribute{name = Name, base = BaseOrEnum}| T], Acc) ->
     Key = list_to_atom(Name),
-    Value = def_erl(erl_type(Type)),
+    Value = erl_type(BaseOrEnum),
     def_attrs(T, Acc#{Key => Value});
 def_attrs([], Acc) ->
     Acc.
+
+erl_type(#base{erl_type = ET}) ->
+    def_erl(ET);
+erl_type(#enum{values = [{Key,_Value}|_]}) ->
+    Key.
 
 def_erl(string) -> <<"ö"/utf8>>;
 def_erl(integer) -> 17;
 def_erl(float) -> 1.0;
 def_erl(boolean) -> true.
-
-erl_type({_,_} = T) ->
-    #base{erl_type = ET} = ews_xsd:to_base(T),
-    ET;
-erl_type(T) ->
-    #base{erl_type = ET} = ews_xsd:to_base({"no_ns", T}),
-    ET.

--- a/src/ews_test.erl
+++ b/src/ews_test.erl
@@ -156,6 +156,10 @@ def_attrs([#attribute{ name = {_, Name}, type = Type}| T], Acc) ->
     Key = list_to_atom(Name),
     Value = def_erl(erl_type(Type)),
     def_attrs(T, Acc#{Key => Value});
+def_attrs([#attribute{ name = Name, type = Type}| T], Acc) ->
+    Key = list_to_atom(Name),
+    Value = def_erl(erl_type(Type)),
+    def_attrs(T, Acc#{Key => Value});
 def_attrs([], Acc) ->
     Acc.
 

--- a/src/ews_test.erl
+++ b/src/ews_test.erl
@@ -149,6 +149,8 @@ def_elems([#elem{type = {_,_} = Qname,
     [[def_type({no_name, Qname}, Tbl)] | def_elems(T, Tbl)];
 def_elems([#elem{type = {_,_} = Qname} | T], Tbl) ->
     [def_type({no_name, Qname}, Tbl) | def_elems(T, Tbl)];
+def_elems([#sc{type = Qname, meta = Meta} | T], Tbl) ->
+    def_elems([#elem{type = Qname, meta = Meta} | T], Tbl);
 def_elems([], _) ->
     [].
 

--- a/src/ews_test.erl
+++ b/src/ews_test.erl
@@ -73,7 +73,7 @@ test_in(InHdr, In, Model, Service, Op, Tbl) ->
     ?assertMatch(Service, Svc),
     ?assertMatch(Op, OpName),
     ?assertMatch(InHdrVals, InHdrs),
-    cond_assert(InVals, InRes),
+    ?assertMatch(InVals, InRes),
     ok.
 
 test_out(OutHdr, Out, Model, Service, Op, Tbl) ->
@@ -89,7 +89,7 @@ test_out(OutHdr, Out, Model, Service, Op, Tbl) ->
     {ok, HdrOut, OpOut} = ews:decode_service_op_result(Model, Service, Op,
                                                        HdrResp, Resp),
     ?assertMatch(OutHdrVals, HdrOut),
-    cond_assert(OutVals, OpOut),
+    ?assertMatch(OutVals, OpOut),
     ok.
 
 test_fault(undefined, _, _, _, _, _) -> ok;
@@ -170,9 +170,3 @@ erl_type({_,_} = T) ->
 erl_type(T) ->
     #base{erl_type = ET} = ews_xsd:to_base({"no_ns", T}),
     ET.
-
-%% TODO: ews should decode empty record, but it seems it doesn't
-cond_assert([{_}], _) ->
-    ok;
-cond_assert(In, Res) ->
-    ?assertMatch(In, Res).

--- a/src/ews_wsdl.erl
+++ b/src/ews_wsdl.erl
@@ -57,7 +57,7 @@ fetch(WsdlUrl) ->
     end.
 
 parse(WsdlBin, Model) when is_atom(Model) ->
-    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
+    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),
@@ -75,7 +75,7 @@ parse(WsdlBin, Model) when is_atom(Model) ->
           types=Types}.
 
 parse(WsdlBin, Model, BaseUrl) when is_atom(Model) ->
-    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
+    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),
@@ -101,7 +101,7 @@ parse(WsdlBin, Model, BaseUrl) when is_atom(Model) ->
 parse_local(WsdlPath, Model) when is_atom(Model) ->
     {ok, WsdlBin} = file:read_file(WsdlPath),
     WsdlBasePath = filename:dirname(WsdlPath),
-    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
+    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),

--- a/src/ews_wsdl.erl
+++ b/src/ews_wsdl.erl
@@ -57,7 +57,8 @@ fetch(WsdlUrl) ->
     end.
 
 parse(WsdlBin, Model) when is_atom(Model) ->
-    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
+    %% Yes, binary_to_list. Let xmerl figure out the encoding.
+    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),
@@ -75,7 +76,8 @@ parse(WsdlBin, Model) when is_atom(Model) ->
           types=Types}.
 
 parse(WsdlBin, Model, BaseUrl) when is_atom(Model) ->
-    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
+    %% Yes, binary_to_list. Let xmerl figure out the encoding.
+    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),
@@ -99,9 +101,10 @@ parse(WsdlBin, Model, BaseUrl) when is_atom(Model) ->
 %% ews_wsdl:parse_local("mm_api/META-INF/wsdl/public/Recipient.wsdl", mm_rpc).
 %%
 parse_local(WsdlPath, Model) when is_atom(Model) ->
+    %% Yes, binary_to_list. Let xmerl figure out the encoding.
     {ok, WsdlBin} = file:read_file(WsdlPath),
     WsdlBasePath = filename:dirname(WsdlPath),
-    {WsdlDoc, _} = xmerl_scan:string(unicode:characters_to_list(WsdlBin),
+    {WsdlDoc, _} = xmerl_scan:string(binary_to_list(WsdlBin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
                                       {validation, schema}]),

--- a/src/ews_xml.erl
+++ b/src/ews_xml.erl
@@ -1,3 +1,4 @@
+%% coding: utf-8
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Copyright (c) 2013-2017 Campanja
 %%% Copyright (c) 2017-2020 [24]7.ai
@@ -79,7 +80,7 @@ emit_tag({txt, Content}, _) ->
 emit_tag({{Ns, txt}, Content}, Nss) ->
     %% Ugly hack for namespaced txts
     {Prefix, _XmlNsDecl, _NewNss} = get_ns_prefix(Ns, Nss),
-    to_string({Prefix, export_text(Content)});
+    to_utf8_string({Prefix, export_text(Content)});
 emit_tag({{Ns, Name}, Attributes, Children}, Nss) ->
     {Prefix, XmlNsDecl, NewNss} = get_ns_prefix(Ns, Nss),
     QName = {Prefix, Name},
@@ -102,14 +103,17 @@ emit_attributes([{{NsN, N}, {NsV, V}} | Attrs], Nss, Acc) ->
     {PrefixN, XmlNsDeclN, NewNss} = get_ns_prefix(NsN, Nss),
     {PrefixV, XmlNsDeclV, NewerNss} = get_ns_prefix(NsV, NewNss),
     NewAttrs = lists:usort(XmlNsDeclN ++ XmlNsDeclV) ++
-               [{to_string({PrefixN, N}), to_string({PrefixV, V})}] ++ Attrs,
+               [{to_utf8_string({PrefixN, N}),
+                 to_utf8_string({PrefixV, V})}] ++ Attrs,
     emit_attributes(NewAttrs, NewerNss, Acc);
 emit_attributes([{{Ns, N}, Value} | Attrs], Nss, Acc) ->
     {Prefix, XmlNsDecl, NewNss} = get_ns_prefix(Ns, Nss),
-    NewAttrs = XmlNsDecl++[{to_string({Prefix, N}), Value}]++Attrs,
+    NewAttrs = XmlNsDecl++[{to_utf8_string({Prefix, N}),
+                            to_utf8_string(Value)}]++Attrs,
     emit_attributes(NewAttrs, NewNss, Acc);
 emit_attributes([{Key, Value} | Attrs], Nss, Acc) ->
-    emit_attributes(Attrs, Nss, [[to_string(Key), "=\"", Value, "\""] | Acc]);
+    emit_attributes(Attrs, Nss, [[to_utf8_string(Key), "=\"",
+                                  to_utf8_string(Value), "\""] | Acc]);
 emit_attributes([], _, Acc) ->
     [" ", string:join(lists:reverse(Acc), " ")].
 
@@ -121,19 +125,25 @@ emit_children(Name, Children, Nss) ->
     [">", [ emit_tag(C, Nss) || C <- Children ], emit_end_tag(Name)].
 
 emit_start_tag({Ns, Name}) ->
-    ["<", to_string(Ns), ":", to_string(Name)];
+    ["<", to_utf8_string(Ns), ":", to_utf8_string(Name)];
 emit_start_tag(Name) ->
-    ["<", to_string(Name)].
+    ["<", to_utf8_string(Name)].
 
 emit_end_tag({Ns, Name}) ->
-    ["</", to_string(Ns), ":", to_string(Name), ">"];
+    ["</", to_utf8_string(Ns), ":", to_utf8_string(Name), ">"];
 emit_end_tag(Name) ->
-    ["</", to_string(Name), ">"].
+    ["</", to_utf8_string(Name), ">"].
 
-to_string({Ns, Name}) -> [Ns, ":", Name];
-to_string(Name) when is_atom(Name) -> atom_to_list(Name);
-to_string(Name) when is_binary(Name) -> binary_to_list(Name);
-to_string(Name) when is_list(Name) -> Name.
+to_utf8_string({Ns, Name}) ->
+    [to_utf8_string(Ns), ":", to_utf8_string(Name)];
+to_utf8_string(Name) when is_atom(Name) -> utf8_atom_to_list(Name);
+to_utf8_string(Name) when is_binary(Name) -> binary_to_list(Name);
+to_utf8_string(Name) when is_list(Name) ->
+    binary_to_list(
+      unicode:characters_to_binary(Name, unicode, utf8)).
+
+utf8_atom_to_list(Atom) ->
+    binary_to_list(atom_to_binary(Atom)).
 
 %% Escape special characters `\r` `<' and `&', flattening the text.
 %% Also escapes `>', just for symmetry.
@@ -451,5 +461,11 @@ split_on_space_test() ->
         binary_to_list(
           <<"<res />"/utf8>>),
     ?assertMatch(["res"], split_on_space(TestTag)).
+
+to_utf8_string_test() ->
+    ?assertMatch(["Ã¶",":","Ã¶"], to_utf8_string({"ö","ö"})),
+    ?assertMatch("Ã¶", to_utf8_string(ö)),
+    ?assertMatch("Ã¶", to_utf8_string(<<"ö"/utf8>>)),
+    ?assertMatch("Ã¶", to_utf8_string("ö")).
 
 -endif.

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -44,11 +44,11 @@
 -include("ews.hrl").
 -include_lib("ews/include/ews.hrl").
 
--define(HTTP_OPTS, [ {connect_options,
-                      [ {connect_timeout, timer:seconds(400)}
-                      , {recv_timeout, timer:seconds(400)}
-                      ]}
-                   , with_body
+-define(HTTP_OPTS, [ %% {connect_options,
+                     %%  [ {connect_timeout, timer:seconds(400)}
+                     %%  , {recv_timeout, timer:seconds(400)}
+                     %%  ]}
+                    with_body
                    ]).
 
 -ifdef(DEBUG).

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -250,6 +250,7 @@ request_cached(SchemaUrl, BaseDir) ->
                 {ok, _, _, Bin} ->
                     {error, Bin};
                 {error, Error} ->
+                    logger:error("Problem fetching XSD: ~tp~n", [SchemaUrl]),
                     {error, Error}
             end;
         %% Not a URI, fetch locally
@@ -259,6 +260,7 @@ request_cached(SchemaUrl, BaseDir) ->
                 {ok, Bin} ->
                     {ok, Bin};
                 {error, Error} ->
+                    logger:error("Problem fetching XSD: ~tp~n", [XSDFilename]),
                     {error, Error}
             end
     end.

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -17,7 +17,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% ---------------------------------------------------------------------------
 %%% WSDL Types parsing
-%%% Doesn't support: group, attributeGroup, include and notation types
+%%% Doesn't support: group, attributeGroup and notation types
 %%%                  unique, key or keyref
 %%% FIXME: Merge elements and types.
 %%% ---------------------------------------------------------------------------

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -173,6 +173,7 @@ find_imports(#schema{types=Schema}) ->
        wh:get_attribute(I, schemaLocation)} || I <- Imports ].
 
 import_schema(SchemaUrl, ImpNs) ->
+    %%logger:notice("Import: ~tp~n", [SchemaUrl]),
     {ok, Bin} = request_cached(SchemaUrl),
     {Schemas, _} = xmerl_scan:string(binary_to_list(Bin),
                                      [{space, normalize},
@@ -181,6 +182,7 @@ import_schema(SchemaUrl, ImpNs) ->
     find_schema(split_schemas(Schemas), ImpNs).
 
 import_schema(SchemaUrl, ImpNs, BaseDir) ->
+    %%logger:notice("Import: ~tp  (~tp)~n", [SchemaUrl, BaseDir]),
     {ok, Bin} = request_cached(SchemaUrl, BaseDir),
     {Schemas, _} = xmerl_scan:string(binary_to_list(Bin),
                                      [{space, normalize},
@@ -556,6 +558,7 @@ to_integer(List) when is_list(List) ->
     list_to_integer(List).
 
 parse_restriction_property(Restriction) ->
+    %%logger:notice("Restriction: ~tp~n", [Restriction]),
     Value = wh:get_attribute(Restriction, value),
     case wh:get_simple_name(Restriction) of
         "minExclusive" ->
@@ -690,10 +693,12 @@ process([#element{parts=[{doc, _}]} = E | Rest], Retry, Ts, TypeAcc, ElemAcc,
         TypeMap, Model, Parent, AttrAcc) ->
     process([E#element{parts=[]} | Rest], Retry, Ts, TypeAcc, ElemAcc, TypeMap,
             Model, Parent, AttrAcc);
-process([#element{name=_Name, type=#reference{name=Qname}, parts=[]} = E | Rest],
+process([#element{name=Name, type=#reference{name=RName}, parts=[]} = E | Rest],
         Retry, Ts,
         TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc) ->
     Meta = parse_meta(E),
+    %%logger:notice("Element with ref: ~tp~n", [E]),
+    Qname = type_qname(RName, Name),
     %% this is a reference, replace with definition and try again
     case ews_model:get_elem(Qname, TypeMap) of
         false ->
@@ -713,7 +718,7 @@ process([#element{name=_Name, type=#reference{name=Qname}, parts=[]} = E | Rest]
 process([#element{name=Qname, type=T, parts=[]} = E | Rest], Retry, Ts,
         TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc) ->
     Meta = parse_meta(E),
-    Qtype = qname(T, no_ns),
+    Qtype = type_qname(T, Qname),
     case to_base(Qtype) of
         false ->
             case lists:keyfind(Qtype, 1, Ts) of
@@ -766,6 +771,66 @@ type_name({Ns, N}, {_, Parent}) ->
     {Ns, Parent++"@"++N};
 type_name({Ns, N}, root) ->
     {Ns, N}.
+
+type_qname({_,_} = Qname, _) ->
+    Qname;
+type_qname(Name, {Ns, _}) ->
+    case is_builtin(Name) of
+        true -> {"no_ns", Name};
+        false -> {Ns, Name}
+    end.
+
+is_builtin("anyURI") -> true;
+is_builtin("anyAtomicType") -> true;
+is_builtin("anySimpleType") -> true;
+is_builtin("base64Binary") -> true;
+is_builtin("boolean") -> true;
+is_builtin("byte") -> true;
+is_builtin("date") -> true;
+is_builtin("dateTime") -> true;
+is_builtin("dateTimeStamp") -> true;
+is_builtin("dayTimeDuration") -> true;
+is_builtin("decimal") -> true;
+is_builtin("double") -> true;
+is_builtin("duration") -> true;
+is_builtin("ENTITIES") -> true;
+is_builtin("ENTITY") -> true;
+is_builtin("float") -> true;
+is_builtin("gDay") -> true;
+is_builtin("gMonth") -> true;
+is_builtin("gMonthDay") -> true;
+is_builtin("gYear") -> true;
+is_builtin("gYearMonth") -> true;
+is_builtin("hexBinary") -> true;
+is_builtin("ID") -> true;
+is_builtin("IDREF") -> true;
+is_builtin("IDREFS") -> true;
+is_builtin("int") -> true;
+is_builtin("integer") -> true;
+is_builtin("language") -> true;
+is_builtin("long") -> true;
+is_builtin("Name") -> true;
+is_builtin("NCName") -> true;
+is_builtin("negativeInteger") -> true;
+is_builtin("NMTOKEN") -> true;
+is_builtin("NMTOKENS") -> true;
+is_builtin("nonNegativeInteger") -> true;
+is_builtin("nonPositiveInteger") -> true;
+is_builtin("normalizedString") -> true;
+is_builtin("NOTATION") -> true;
+is_builtin("positiveInteger") -> true;
+is_builtin("precisionDecimal") -> true;
+is_builtin("QName") -> true;
+is_builtin("short") -> true;
+is_builtin("string") -> true;
+is_builtin("time") -> true;
+is_builtin("token") -> true;
+is_builtin("unsignedByte") -> true;
+is_builtin("unsignedInt") -> true;
+is_builtin("unsignedLong") -> true;
+is_builtin("unsignedShort") -> true;
+is_builtin("yearMonthDuration") -> true;
+is_builtin(OtherType) when is_list(OtherType) -> false.
 
 process_all_simple([#simple_type{name=Qname} = S | Rest]) ->
     [{Qname, process_simple(S)} | process_all_simple(Rest) ];

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -241,7 +241,9 @@ request_cached(SchemaUrl) ->
     end.
 
 request_cached(SchemaUrl, BaseDir) ->
-    CacheDir = application:get_env(ews, cache_base_dir, code:priv_dir(ews)),
+    CacheApp = application:get_env(ews, cache_base_app, ews),
+    CacheDir = application:get_env(ews, cache_base_dir,
+                                   code:priv_dir(CacheApp)),
     File = filename:join([CacheDir, "xsds", escape_slash(SchemaUrl)]),
     ok = filelib:ensure_dir(File),
     URI = uri_string:parse(SchemaUrl),

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -236,6 +236,7 @@ request_cached(SchemaUrl) ->
                 {ok, _, _, Bin} ->
                     {error, Bin};
                 {error, Error} ->
+                    logger:error("Problem fetching XSD: ~tp~n", [SchemaUrl]),
                     {error, Error}
             end
     end.

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -175,6 +175,7 @@ find_imports(#schema{types=Schema}) ->
 import_schema(SchemaUrl, ImpNs) ->
     %%logger:notice("Import: ~tp~n", [SchemaUrl]),
     {ok, Bin} = request_cached(SchemaUrl),
+    %% Yes, binary_to_list. Let xmerl figure out the encoding.
     {Schemas, _} = xmerl_scan:string(binary_to_list(Bin),
                                      [{space, normalize},
                                       {namespace_conformant, true},
@@ -184,6 +185,7 @@ import_schema(SchemaUrl, ImpNs) ->
 import_schema(SchemaUrl, ImpNs, BaseDir) ->
     %%logger:notice("Import: ~tp  (~tp)~n", [SchemaUrl, BaseDir]),
     {ok, Bin} = request_cached(SchemaUrl, BaseDir),
+    %% Yes, binary_to_list. Let xmerl figure out the encoding.
     {Schemas, _} = xmerl_scan:string(binary_to_list(Bin),
                                      [{space, normalize},
                                       {namespace_conformant, true},

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -328,7 +328,7 @@ parse_type(#xmlElement{} = Type) ->
         "notation" ->
             notation;
         Other ->
-            ?log("ERROR: unrecognized xsd-element: ~p~n",
+            logger:warning("ERROR: unrecognized xsd-element: ~p~n",
                  [Other]),
             {error, {unknown_type, Other}}
     end.
@@ -364,23 +364,42 @@ maybe_ref(Qname, Element) ->
 
 parse_complex_type(ComplexType) ->
     Name = wh:get_attribute(ComplexType, name),
-    %%logger:notice("ComplexType: ~p~n", [Name]),
+    %% logger:notice("ComplexType: ~p~n", [Name]),
     Abstract = wh:get_attribute(ComplexType, abstract),
     Children = wh:get_all_child_elements(ComplexType),
+    %%logger:notice("Children: ~tp~n", [Children]),
     Restriction = parse_type(wh:find_element(ComplexType, "restriction")),
     Extension = parse_type(wh:find_element(ComplexType, "extension")),
     case Children of
-        [#xmlElement{name = simpleContent} = SimpleContent] ->
+        [#xmlElement{expanded_name =
+                         {'http://www.w3.org/2001/XMLSchema',
+                          simpleContent}} = SimpleContent] ->
             RestrictionSC = parse_type(wh:find_element(SimpleContent,
                                                        "restriction")),
             ExtensionSC = parse_type(wh:find_element(SimpleContent, "extension")),
             %% TODO: handle extenstions without this ugly hack
             %% This is converted to a simple_type since we don't want to emit
-            %% a record for a simpleContent
+            %% a record for a simpleContent.
+            %% Unless of course the simpleContent has attributes, then we
+            %% need to emit a special record like this:
+            %% -record(foo, {'__attrs' :: #{bar => string() | binary()} | undefined
+            %%               value :: integer() | undefined}).
             RestrictionFinal = extract_base(RestrictionSC, ExtensionSC),
-            #simple_type{name=Name,
-                         restrictions=RestrictionFinal
-                         };
+            %% logger:notice("SimpleContent: ~tp~n", [SimpleContent]),
+            %% logger:notice("ExtensionSC: ~tp~n", [ExtensionSC]),
+            #extension{parts=ExtensionParts} = ExtensionSC,
+            case [ EP || #attribute{} = EP <- ExtensionParts ] of
+                [] ->
+                    #simple_type{name=Name,
+                                 restrictions=RestrictionFinal
+                                };
+                [#attribute{} | _] = Attributes ->
+                    %% logger:notice("SimpleContentAttrs: ~tp~n", [Attributes]),
+                    #simple_content{name=Name,
+                                    restrictions=RestrictionFinal,
+                                    attrs=Attributes
+                                   }
+            end;
         _ ->
             ChildTypes = [ parse_type(C) || C <- Children ],
             Parts = flatten_children(ChildTypes),
@@ -614,15 +633,21 @@ insert_nss([E = #element{name=N, parts=Ps} | Ts], Ns, Res) ->
                        [{doc, Doc}]
                end,
     insert_nss(Ts, Ns, [E#element{name=qname(N, Ns), parts=NewParts}|Res]);
-insert_nss([A = #attribute{name=N} | Ts], Ns, Res) ->
-    insert_nss(Ts, Ns, [A#attribute{name=qname(N, Ns)}|Res]);
+insert_nss([A = #attribute{type=T} | Ts], Ns, Res) ->
+    insert_nss(Ts, Ns, [A#attribute{type=attr_qname(T, Ns)}|Res]);
 insert_nss([St = #simple_type{name=N} | Ts], Ns, Res) ->
     insert_nss(Ts, Ns, [St#simple_type{name=qname(N, Ns)}|Res]);
+insert_nss([St = #simple_content{name=N,attrs=Attrs} | Ts], Ns, Res) ->
+    NewAttrs = insert_nss(Attrs, Ns, []),
+    %% logger:notice("insert_nss NewAttrs: ~tp~n", [NewAttrs]),
+    NewRes = [St#simple_content{name=qname(N, Ns), attrs=NewAttrs}|Res],
+    insert_nss(Ts, Ns, NewRes);
 insert_nss([Ct = #complex_type{name=N, parts=Ps} | Ts], Ns, Res) ->
     NewPs = insert_nss(Ps, Ns, []),
     NewRes = [Ct#complex_type{name=qname(N, Ns), parts=NewPs}|Res],
     insert_nss(Ts, Ns, NewRes);
 insert_nss([_E | Ts], Ns, Res) ->
+    %% logger:warning("warning: unhandled ~tp~n", [E]),
     insert_nss(Ts, Ns, Res);
 insert_nss([], _, Res) ->
     lists:reverse(Res).
@@ -649,7 +674,7 @@ process(Types, Model) ->
                     {_, _, R2, []} ->
                         %%logger:error("Can't resolve all refs~n~p~n",
                         %%             [lists:usort(ets:tab2list(TypeMap))]),
-                        error({cannot_resolve, R2})
+                        error({cannot_resolve, R2, Ts})
                 end
     end,
     #model{type_map=TypeMap, elems=[], simple_types=Ts}.
@@ -758,13 +783,66 @@ process([#complex_type{name=Qname, extends=Ext, parts=Ps} = CT | Rest], Retry, T
             process(Rest, [CT | Retry], Ts, TypeAcc, ElemAcc, TypeMap, Model,
                     Parent, AttrAcc)
     end;
-process([#attribute{} = A | Rest], Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model,
-        Parent, AttrAcc)->
-    process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent,
-            [ A | AttrAcc]);
+process([#simple_content{name=Qname, restrictions=Restrictions, attrs=Ps} = CT
+        | Rest], Retry, Ts,
+        TypeAcc, ElemAcc, TypeMap, Model, Parent, _AttrAcc) ->
+    #restriction{base_type = Bs} = Restrictions,
+    %% We don't want to pass in Retry in processing of parts
+    case process(Ps, [], Ts, TypeAcc, [], TypeMap, Model, Qname, []) of
+        {AccWithSubTypes, [], [], AttrAcc} ->
+            MaybeBaseOrEnum =
+                case {to_base(type_qname(Bs, Qname)),
+                      lists:keyfind(Bs, 1, Ts)} of
+                    {false, false} -> undefined;
+                    {false, {_Qtype, BOrE}} -> BOrE;
+                    {BOrE, _} -> BOrE
+                end,
+            case MaybeBaseOrEnum of
+                undefined ->
+                    %% logger:error("Can't find simpletype: ~tp~nTs: ~tp~n",
+                    %%              [CT, Ts]),
+                    process(Rest, [CT | Retry], Ts, TypeAcc, ElemAcc, TypeMap,
+                            Model, Parent, AttrAcc);
+                BaseOrEnum ->
+                    SC = #sc{qname={ok,"value"}, type=BaseOrEnum,
+                             %% hard code meta, the encasing element has the
+                             %% correct meta.
+                             meta=#meta{min=1, max=1}},
+                    %% logger:notice("AttrAcc ~tp~n", [AttrAcc]),
+                    Type = #type{qname=Qname,
+                                 elems=[SC],
+                                 attrs=AttrAcc},
+                    ews_model:put(Type, Model, TypeMap),
+                    process(Rest, Retry, Ts, [Type | AccWithSubTypes], ElemAcc,
+                            TypeMap, Model, Parent, [])
+            end;
+        {_, _, [_|_], AttrAcc} ->
+            process(Rest, [CT | Retry], Ts, TypeAcc, ElemAcc, TypeMap, Model,
+                    Parent, AttrAcc)
+    end;
+process([#attribute{type=Type, base=undefined} = A | Rest], Retry, Ts, TypeAcc,
+        ElemAcc, TypeMap, Model, Parent, AttrAcc)->
+    case to_base(Type) of
+        false ->
+            case lists:keyfind(Type, 1, Ts) of
+                false ->
+                    logger:error("Can't find simpletype: ~tp~n",
+                                 [Type]),
+                    process(Rest, [A | Retry], Ts, TypeAcc, ElemAcc, TypeMap,
+                            Model, Parent, AttrAcc);
+                {_Qtype, BaseOrEnum} ->
+                    NewA = A#attribute{base=BaseOrEnum},
+                    process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap,
+                            Model, Parent, [NewA | AttrAcc])
+            end;
+        #base{} = Base ->
+            NewA = A#attribute{base=Base},
+            process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap,
+                    Model, Parent, [NewA | AttrAcc])
+    end;
 process([T | Rest], Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc)
   when not is_record(T, attribute) ->
-    ?log("warning: unhandled ~p~n", [T]),
+    logger:warning("warning: unhandled ~tp~n", [T]),
     process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc);
 process([], Retry, _, TypeAcc, ElemAcc, _TypeMap, _Model, _Parent, AttrAcc) ->
     {TypeAcc, lists:reverse(ElemAcc), Retry, lists:reverse(AttrAcc)}.
@@ -777,6 +855,14 @@ type_name({Ns, N}, root) ->
 type_qname({_,_} = Qname, _) ->
     Qname;
 type_qname(Name, {Ns, _}) ->
+    case is_builtin(Name) of
+        true -> {"no_ns", Name};
+        false -> {Ns, Name}
+    end.
+
+attr_qname({_,_} = Qname, _) ->
+    Qname;
+attr_qname(Name, Ns) ->
     case is_builtin(Name) of
         true -> {"no_ns", Name};
         false -> {Ns, Name}

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -220,7 +220,9 @@ find_schema([], ImpNs) ->
     error({cant_find_import_schema, ImpNs}).
 
 request_cached(SchemaUrl) ->
-    CacheDir = application:get_env(ews, cache_base_dir, code:priv_dir(ews)),
+    CacheApp = application:get_env(ews, cache_base_app, ews),
+    CacheDir = application:get_env(ews, cache_base_dir,
+                                   code:priv_dir(CacheApp)),
     File = filename:join([CacheDir, "xsds", escape_slash(SchemaUrl)]),
     ok = filelib:ensure_dir(File),
     case file:read_file(File) of

--- a/src/ews_xsd.erl
+++ b/src/ews_xsd.erl
@@ -322,7 +322,7 @@ parse_type(#xmlElement{} = Type) ->
         "anyAttribute" ->
             anyAttribute;
         "group" ->
-            group;
+            parse_group(Type);
         "attributeGroup" ->
             attributeGroup;
         "notation" ->
@@ -441,6 +441,21 @@ list_or_union(Simple) ->
             {list, wh:get_child(List, "simpleType")}
     end.
 
+parse_group(Group) ->
+    Ref = wh:get_attribute(Group, ref),
+    maybe_group_ref(Ref, Group).
+
+maybe_group_ref(undefined, Group) ->
+    Name = wh:get_attribute(Group, name),
+    Children = wh:get_all_child_elements(Group),
+    ChildTypes = [ parse_type(C) || C <- Children ],
+    Parts = flatten_children(ChildTypes),
+    #group{name=Name, parts=Parts};
+maybe_group_ref(Reference, Group) ->
+    MinOccurs = to_integer(wh:get_attribute(Group, minOccurs)),
+    MaxOccurs = to_integer(wh:get_attribute(Group, maxOccurs)),
+    #group_ref{ref=Reference,
+               min_occurs=MinOccurs, max_occurs=MaxOccurs}.
 
 parse_attribute(Attribute) ->
     Name = wh:get_attribute(Attribute, name),
@@ -573,7 +588,7 @@ print_schema_stats(Schema) ->
                   length(Notations),
                   length(Annotations)]).
 
-to_integer(undefined) -> 1;
+to_integer(undefined) -> undefined;
 to_integer("unbounded") -> infinite;
 to_integer(List) when is_list(List) ->
     list_to_integer(List).
@@ -646,6 +661,12 @@ insert_nss([Ct = #complex_type{name=N, parts=Ps} | Ts], Ns, Res) ->
     NewPs = insert_nss(Ps, Ns, []),
     NewRes = [Ct#complex_type{name=qname(N, Ns), parts=NewPs}|Res],
     insert_nss(Ts, Ns, NewRes);
+insert_nss([Gr = #group{name=N, parts=Ps} | Ts], Ns, Res) ->
+    NewPs = insert_nss(Ps, Ns, []),
+    NewRes = [Gr#group{name=qname(N, Ns), parts=NewPs}|Res],
+    insert_nss(Ts, Ns, NewRes);
+insert_nss([Grr = #group_ref{ref=N} | Ts], Ns, Res) ->
+    insert_nss(Ts, Ns, [Grr#group_ref{ref=qname(N, Ns)} | Res]);
 insert_nss([_E | Ts], Ns, Res) ->
     %% logger:warning("warning: unhandled ~tp~n", [E]),
     insert_nss(Ts, Ns, Res);
@@ -826,8 +847,8 @@ process([#attribute{type=Type, base=undefined} = A | Rest], Retry, Ts, TypeAcc,
         false ->
             case lists:keyfind(Type, 1, Ts) of
                 false ->
-                    logger:error("Can't find simpletype: ~tp~n",
-                                 [Type]),
+                    %% logger:error("Can't find simpletype: ~tp~n",
+                    %%              [Type]),
                     process(Rest, [A | Retry], Ts, TypeAcc, ElemAcc, TypeMap,
                             Model, Parent, AttrAcc);
                 {_Qtype, BaseOrEnum} ->
@@ -840,12 +861,46 @@ process([#attribute{type=Type, base=undefined} = A | Rest], Retry, Ts, TypeAcc,
             process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap,
                     Model, Parent, [NewA | AttrAcc])
     end;
+process([#group{} = Group | Rest], Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model,
+        Parent, AttrAcc) ->
+    ews_model:put_group(Group, Model, TypeMap),
+    process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc);
+process([#group_ref{ref=Ref, min_occurs=Min, max_occurs=Max} = Grr | Rest],
+        Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc) ->
+    %% logger:notice("GroupRef: ~tp~n", [Ref]),
+    case ews_model:get_group(Ref, Model, TypeMap) of
+        false ->
+            process(Rest, [Grr | Retry], Ts, TypeAcc, ElemAcc, TypeMap, Model,
+                    Parent, AttrAcc);
+        #group{parts=Ps} ->
+            %% Turn a group into a sequence
+            NewPs = propagate_meta(Ps, Min, Max),
+            process(NewPs ++ Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model,
+                    Parent, AttrAcc)
+    end;
 process([T | Rest], Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc)
   when not is_record(T, attribute) ->
     logger:warning("warning: unhandled ~tp~n", [T]),
     process(Rest, Retry, Ts, TypeAcc, ElemAcc, TypeMap, Model, Parent, AttrAcc);
 process([], Retry, _, TypeAcc, ElemAcc, _TypeMap, _Model, _Parent, AttrAcc) ->
     {TypeAcc, lists:reverse(ElemAcc), Retry, lists:reverse(AttrAcc)}.
+
+propagate_meta([#element{min_occurs=Min, max_occurs=Max} = E | T],
+               RefMin, RefMax) ->
+    [E#element{min_occurs=maybe_override(RefMin, Min),
+               max_occurs=maybe_override(RefMax, Max)} |
+     propagate_meta(T, RefMin, RefMax)];
+propagate_meta([#group_ref{min_occurs=Min, max_occurs=Max} = Grr | T],
+               RefMin, RefMax) ->
+    [Grr#group_ref{min_occurs=maybe_override(RefMin, Min),
+                   max_occurs=maybe_override(RefMax, Max)} |
+     propagate_meta(T, RefMin, RefMax)];
+propagate_meta([], _, _) ->
+    [].
+
+maybe_override(undefined, undefined) -> 1;
+maybe_override(undefined, N) -> N;
+maybe_override(N, _) -> N.
 
 type_name({Ns, N}, {_, Parent}) ->
     {Ns, Parent++"@"++N};
@@ -941,7 +996,10 @@ process_simple(#simple_type{restrictions=Rs, order=Order}) ->
 
 parse_meta(#element{default=D, fixed=F, nillable=N,
                     min_occurs=Min, max_occurs=Max}) ->
-    #meta{nillable=N, default=D, fixed=F, min=Min, max=Max}.
+    #meta{nillable=N, default=D, fixed=F, min=def_one(Min), max=def_one(Max)}.
+
+def_one(undefined) -> 1;
+def_one(Any) -> Any.
 
 %% TODO: Handle more refined basic spec types (i.e. non_neg_integer() etc)
 to_base({"http://www.w3.org/2001/XMLSchema", "boolean"} = Qn) ->

--- a/src/wh.erl
+++ b/src/wh.erl
@@ -41,8 +41,15 @@ get_attribute(#xmlElement{attributes=Attrs, namespace=Ns}, Name) ->
             case lists:member($:, Attr) of
                 true when not IsHttp ->
                     [Tns, BaseName] = string:tokens(Attr, ":"),
-                    {_, Uri} = lists:keyfind(Tns, 1, Ns#xmlNamespace.nodes),
-                    {atom_to_list(Uri), BaseName};
+                    case lists:keyfind(Tns, 1
+                                      , Ns#xmlNamespace.nodes) of
+                        {_, Uri} ->
+                            {atom_to_list(Uri), BaseName};
+                        %% FIXME: do something smarter to find attrs like
+                        %% "[\\w\\d\\p{Zs}\\-/_.,:]*"
+                        false ->
+                            Attr
+                    end;
                 _ ->
                     Attr
             end

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -19,7 +19,7 @@
         , colliding_types/1
         , empty_records_decode/1
         , serialize_deserialize/1
-        , dont_emit_simplecontent/1
+        %% , dont_emit_simplecontent/1
         , many_schemas_n_refs/1
         ]).
 
@@ -31,8 +31,8 @@ groups() ->
         google_v201306_correct_service
        ]}
     , {mm_service,
-       [ dont_emit_simplecontent
-       , empty_records_decode
+       [ %% dont_emit_simplecontent
+         empty_records_decode
        ]}
     , {mm_notification,
        [ colliding_types
@@ -100,26 +100,26 @@ google_v201306_correct_service(Config) ->
     [ResService] = Wsdl#wsdl.services,
     "CampaignService" = ResService#service.name.
 
-dont_emit_simplecontent(_Config) ->
-    Dir = filename:join(code:priv_dir(ews), "../test"),
-    File = filename:join(Dir, "mm_service.wsdl"),
-    %% Mock request
-    meck:new(hackney),
-    meck:expect(hackney, request, 5, {ok, 200, ignore, <<>>}),
-    ews:add_wsdl_to_model(ek_mm_test, File),
-    #model{type_map=Tbl, simple_types=Ts} =
-        ews_svc:get_model(ek_mm_test),
-    Ret = ews_emit:sort_types(Tbl, Ts),
-    %% Nothing should be unresolved
-    ?assertMatch({[], [_|_]}, Ret),
-    %% This simpleContent should not be in Tbl
-    ?assertEqual(false,
-                 ews_model:get({"http://www.w3.org/2000/09/xmldsig#",
-                                "SignatureValueType"}
-                              , Tbl)),
-    ok = ews_test:test_everything(ek_mm_test),
-    meck:unload(hackney),
-    ok.
+%% dont_emit_simplecontent(_Config) ->
+%%     Dir = filename:join(code:priv_dir(ews), "../test"),
+%%     File = filename:join(Dir, "mm_service.wsdl"),
+%%     %% Mock request
+%%     meck:new(hackney),
+%%     meck:expect(hackney, request, 5, {ok, 200, ignore, <<>>}),
+%%     ews:add_wsdl_to_model(ek_mm_test, File),
+%%     #model{type_map=Tbl, simple_types=Ts} =
+%%         ews_svc:get_model(ek_mm_test),
+%%     Ret = ews_emit:sort_types(Tbl, Ts),
+%%     %% Nothing should be unresolved
+%%     ?assertMatch({[], [_|_]}, Ret),
+%%     %% This simpleContent should not be in Tbl
+%%     ?assertEqual(false,
+%%                  ews_model:get({"http://www.w3.org/2000/09/xmldsig#",
+%%                                 "SignatureValueType"}
+%%                               , Tbl)),
+%%     ok = ews_test:test_everything(ek_mm_test),
+%%     meck:unload(hackney),
+%%     ok.
 
 empty_records_decode(_Config) ->
     Dir = filename:join(code:priv_dir(ews), "../test"),
@@ -147,7 +147,7 @@ empty_records_decode(_Config) ->
     OutMessage =
         [{get_posers_response,
           <<"fluster">>,
-          {secret, undefined},
+          {secret, #{'sattAv' => ja}, nej},
           13}],
     OutSOAP =
         iolist_to_binary(

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -16,6 +16,7 @@
 -export([ google_v201306_ensure_record/1
         , google_v201306_correct_service/1
         , colliding_types/1
+        , empty_records_decode/1
         , serialize_deserialize/1
         , dont_emit_simplecontent/1
         , many_schemas_n_refs/1
@@ -30,6 +31,7 @@ groups() ->
        ]}
     , {mm_service,
        [ dont_emit_simplecontent
+       , empty_records_decode
        ]}
     , {mm_notification,
        [ colliding_types
@@ -115,6 +117,31 @@ dont_emit_simplecontent(_Config) ->
                                 "SignatureValueType"}
                               , Tbl)),
     ok = ews_test:test_everything(ek_mm_test),
+    ok.
+
+empty_records_decode(_Config) ->
+    Dir = filename:join(code:priv_dir(ews), "../test"),
+    File = filename:join(Dir, "mm_service.wsdl"),
+    %% Mock request
+    meck:new(hackney),
+    meck:expect(hackney, request, 5, {ok, 200, ignore, <<>>}),
+    ews:add_wsdl_to_model(ek_mm_test, File),
+    %%ews:emit_complete_model_types(ek_mm_test, "/tmp/le_service.hrl"),
+    %% "client" serializes request
+    PoserMessage =
+        [{get_posers}],
+    %%ok = ews:get_service_op_info(ek_mm_test, "service", "poser"),
+    PoserSOAP = ews:serialize_service_op( ek_mm_test
+                                        , "service"
+                                        , "poser"
+                                        , []
+                                        , PoserMessage
+                                        ),
+    {ok, {Svc, OpName, [], OpIn}} = ews:decode_in(ek_mm_test, PoserSOAP),
+    logger:notice("PoserSOAP: ~tp~n", [PoserSOAP]),
+    ?assertMatch("service", Svc),
+    ?assertMatch("poser", OpName),
+    ?assertMatch(PoserMessage, OpIn),
     ok.
 
 colliding_types(_Config) ->

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -19,7 +19,7 @@
         , colliding_types/1
         , empty_records_decode/1
         , serialize_deserialize/1
-        %% , dont_emit_simplecontent/1
+        , test_mm_service/1
         , many_schemas_n_refs/1
         ]).
 
@@ -31,8 +31,8 @@ groups() ->
         google_v201306_correct_service
        ]}
     , {mm_service,
-       [ %% dont_emit_simplecontent
-         empty_records_decode
+       [ test_mm_service
+       , empty_records_decode
        ]}
     , {mm_notification,
        [ colliding_types
@@ -100,26 +100,16 @@ google_v201306_correct_service(Config) ->
     [ResService] = Wsdl#wsdl.services,
     "CampaignService" = ResService#service.name.
 
-%% dont_emit_simplecontent(_Config) ->
-%%     Dir = filename:join(code:priv_dir(ews), "../test"),
-%%     File = filename:join(Dir, "mm_service.wsdl"),
-%%     %% Mock request
-%%     meck:new(hackney),
-%%     meck:expect(hackney, request, 5, {ok, 200, ignore, <<>>}),
-%%     ews:add_wsdl_to_model(ek_mm_test, File),
-%%     #model{type_map=Tbl, simple_types=Ts} =
-%%         ews_svc:get_model(ek_mm_test),
-%%     Ret = ews_emit:sort_types(Tbl, Ts),
-%%     %% Nothing should be unresolved
-%%     ?assertMatch({[], [_|_]}, Ret),
-%%     %% This simpleContent should not be in Tbl
-%%     ?assertEqual(false,
-%%                  ews_model:get({"http://www.w3.org/2000/09/xmldsig#",
-%%                                 "SignatureValueType"}
-%%                               , Tbl)),
-%%     ok = ews_test:test_everything(ek_mm_test),
-%%     meck:unload(hackney),
-%%     ok.
+test_mm_service(_Config) ->
+    Dir = filename:join(code:priv_dir(ews), "../test"),
+    File = filename:join(Dir, "mm_service.wsdl"),
+    %% Mock request
+    meck:new(hackney),
+    meck:expect(hackney, request, 5, {ok, 200, ignore, <<>>}),
+    ews:add_wsdl_to_model(ek_mm_test, File),
+    ok = ews_test:test_everything(ek_mm_test),
+    meck:unload(hackney),
+    ok.
 
 empty_records_decode(_Config) ->
     Dir = filename:join(code:priv_dir(ews), "../test"),

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -143,6 +143,27 @@ empty_records_decode(_Config) ->
     ?assertMatch("service", Svc),
     ?assertMatch("poser", OpName),
     ?assertMatch(PoserMessage, OpIn),
+    OutMessage =
+        [{get_posers_response,
+          <<"fluster">>,
+          {secret, undefined},
+          13}],
+    OutSOAP =
+        iolist_to_binary(
+          ews:encode_service_op_result( ek_mm_test
+                                      , "service"
+                                      , "poser"
+                                      , []
+                                      , OutMessage
+                                      )),
+    XmlTerm = ews_xml:decode(OutSOAP),
+    {ok, {HdrResp, Resp}} = ews_soap:parse_envelope(XmlTerm),
+    {ok, _HdrOut, OpOut} = ews:decode_service_op_result( ek_mm_test
+                                                      , "service"
+                                                      , "poser"
+                                                      , HdrResp
+                                                      , Resp),
+    ?assertMatch(OutMessage, OpOut),
     meck:unload(hackney),
     ok.
 

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -1,3 +1,4 @@
+%% coding: utf-8
 -module(ews_wsdl_SUITE).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -259,6 +260,13 @@ many_schemas_n_refs(_Config) ->
                                     test_wsdl_file("tiny.wsdl")),
     TmpFile = tempfile(),
     ok = ews:emit_complete_model_types(tiny, TmpFile),
+    %% Test so generated .hrl file does not contain latin-1
+    {ok, Utf8File} = file:read_file(TmpFile),
+    UnicodeString = unicode:characters_to_list(Utf8File, utf8),
+    ?assertNotMatch({incomplete,_,_}, UnicodeString),
+    ?assertNotMatch({error,_,_}, UnicodeString),
+    ?assertMatch(true, is_list(UnicodeString)),
+    %% Test a message
     Find = [{find,
              {find_love_class,
               #{'UserId' => <<"TEST">>,
@@ -269,7 +277,8 @@ many_schemas_n_refs(_Config) ->
                #{'Gender' => <<"Foden">>,
                  'Internet' => 1},
                undefined,
-               <<"197001011234">>},
+               <<"197001011234">>,
+              'skriven på adressen'},
               {query_columns_class,
                #{'Vkiid' => 1,
                  'Vkid' => 1}}}}],

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -117,6 +117,7 @@ dont_emit_simplecontent(_Config) ->
                                 "SignatureValueType"}
                               , Tbl)),
     ok = ews_test:test_everything(ek_mm_test),
+    meck:unload(hackney),
     ok.
 
 empty_records_decode(_Config) ->
@@ -142,6 +143,7 @@ empty_records_decode(_Config) ->
     ?assertMatch("service", Svc),
     ?assertMatch("poser", OpName),
     ?assertMatch(PoserMessage, OpIn),
+    meck:unload(hackney),
     ok.
 
 colliding_types(_Config) ->
@@ -177,6 +179,7 @@ colliding_types(_Config) ->
                  ews_model:get(EmailHeaderType, Tbl)),
     ?assertMatch(#type{alias=header, elems=[_]},
                  ews_model:get(SmsHeaderType, Tbl)),
+    meck:unload(hackney),
     ok.
 
 serialize_deserialize(_Config) ->
@@ -227,6 +230,7 @@ serialize_deserialize(_Config) ->
                                                  [Resp]),
 
     ?assertMatch(SmsMessage, OpOut),
+    meck:unload(hackney),
     ok.
 
 many_schemas_n_refs(_Config) ->

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -269,7 +269,7 @@ many_schemas_n_refs(_Config) ->
     %% Test a message
     Find = [{find,
              {find_love_class,
-              #{'UserId' => <<"TEST">>,
+              #{'UserId' => <<"TöST"/utf8>>,
                 'Password' => <<"TEST">>,
                 'AccountID' => <<>>,
                 'TargetType' => 1},
@@ -284,13 +284,14 @@ many_schemas_n_refs(_Config) ->
                  'Vkid' => 1}}}}],
     ct:pal("Find: ~p", [Find]),
     Header = [{api_soap_header, <<"apa">>, undefined}],
-    FindSOAP = iolist_to_binary(
-                 ews:serialize_service_op( tiny
-                                         , "NNAPIWebService"
-                                         , "Find"
-                                         , Header
-                                         , Find
-                                         )),
+    FindSOAP =
+        ews:serialize_service_op( tiny
+                                , "NNAPIWebService"
+                                , "Find"
+                                , Header
+                                , Find
+                                ),
+    ct:pal("FindSOAP:  ~tp~n", [FindSOAP]),
     {ok, {Svc, OpName, OpHdr, OpIn}} = ews:decode_in(tiny, FindSOAP),
     ?assertMatch("NNAPIWebService", Svc),
     ?assertMatch("Find", OpName),

--- a/test/ews_xml_SUITE.erl
+++ b/test/ews_xml_SUITE.erl
@@ -63,8 +63,13 @@ forbidden_characters(_Config) ->
                 [{{"http://minameddelanden.gov.se/schema/Recipient",
                    "AgreementText"},
                   [],
-                  [{txt,<<"yo&\r\n<>öö/utf-8">>}]}]}]}],
-    Output = ews_xml:decode(iolist_to_binary(ews_xml:encode(Input))),
+                  [{txt,<<"yo&\r\n<>öö"/utf8>>}]}]}]}],
+    InIO = ews_xml:encode(Input),
+    ct:pal("InIO: ~tp~n", [InIO]),
+    %%hackney:request(post, <<"http://localhost:12345/">>, [], InIO, []),
+    InSOAP = iolist_to_binary(InIO),
+    ct:pal("InSOAP: ~tp~n", [InSOAP]),
+    Output = ews_xml:decode(InSOAP),
     ?assertMatch(Input, Output).
 
 import_any_order(_Config) ->

--- a/test/mm_service.wsdl
+++ b/test/mm_service.wsdl
@@ -20,6 +20,8 @@
         <xsd:complexType>
           <xsd:sequence>
             <xsd:element name="fluster" type="FlusterType"/>
+            <xsd:element name="apa" ref="Secret"/>
+            <xsd:element name="bepa" type="integer"/>
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
@@ -33,10 +35,35 @@
           <xsd:maxLength value="80"/>
         </xsd:restriction>
       </xsd:simpleType>
+      <xsd:simpleType name="SekretessSattAvTYPE">
+        <xsd:annotation>
+          <xsd:documentation>
+            This should trigger an empty record with just __attrs
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xs:string">
+            <xsd:enumeration value="JA"/>
+          </xsd:restriction>
+      </xsd:simpleType>
+      <xsd:simpleType name="tns:JaNejTYPE">
+        <xsd:restriction base="xs:string">
+          <xsd:enumeration value="JA"/>
+          <xsd:enumeration value="NEJ"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+      <xsd:element name="Secret" type="Secret"/>
+      <xsd:complexType name="Secret">
+        <xsd:simpleContent>
+          <xsd:extension base="tns:JaNejTYPE">
+            <xsd:attribute name="sattAv" type="SekretessSattAvTYPE"/>
+          </xsd:extension>
+        </xsd:simpleContent>
+      </xsd:complexType>
       <xsd:element name="PosersFault">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="code" type="integer"/>
+            <xsd:element name="apa" ref="Secret"/>
+            <xsd:element name="bepa" type="integer"/>
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>

--- a/test/mm_service.wsdl
+++ b/test/mm_service.wsdl
@@ -8,13 +8,41 @@
                   name="service"
                   targetNamespace="http://example.com/service">
   <wsdl:types>
-    <xsd:schema>
+    <xsd:schema targetNamespace="http://example.com/service">
       <xsd:import namespace="http://example.com/importer"
                   schemaLocation="importer.xsd"/>
+      <xsd:element name="getPosers">
+        <xsd:complexType>
+          <xsd:sequence/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="getPosersResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="return" type="integer" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="PosersFault">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="code" type="integer"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
     </xsd:schema>
   </wsdl:types>
   <wsdl:message name="deliveredReq">
     <wsdl:part name="parameters" element="importer:delivered"/>
+  </wsdl:message>
+  <wsdl:message name="getPosersRequest">
+    <wsdl:part name="parameters" element="tns:getPosers"/>
+  </wsdl:message>
+  <wsdl:message name="getPosersResponse">
+    <wsdl:part name="parameters" element="tns:getPosersResponse"/>
+  </wsdl:message>
+  <wsdl:message name="getPosersFault">
+    <wsdl:part name="fault" element="tns:PosersFault"/>
   </wsdl:message>
   <wsdl:portType name="ExamplePort">
     <wsdl:operation name="pokebowl">
@@ -22,10 +50,27 @@
       <wsdl:output message="tns:deliveredReq"/>
       <wsdl:fault name="fault" message="tns:deliveredReq"/>
     </wsdl:operation>
+    <wsdl:operation name="poser">
+      <wsdl:input message="tns:getPosersRequest"/>
+      <wsdl:output message="tns:getPosersResponse"/>
+      <wsdl:fault name="fault" message="tns:getPosersFault"/>
+    </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="ExampleBinding" type="tns:ExamplePort">
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="pokebowl">
+      <soap:operation soapAction=""/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="fault">
+        <soap:fault name="fault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="poser">
       <soap:operation soapAction=""/>
       <wsdl:input>
         <soap:body use="literal"/>

--- a/test/mm_service.wsdl
+++ b/test/mm_service.wsdl
@@ -19,10 +19,20 @@
       <xsd:element name="getPosersResponse">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="return" type="integer" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="fluster" type="FlusterType"/>
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
+      <xsd:simpleType name="FlusterType">
+        <xsd:annotation>
+          <xsd:documentation>This pattern triggered a bug in wh.erl</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xs:string">
+          <xsd:pattern value="[\w\d\p{Zs}\-/_.,:]*"/>
+          <xsd:minLength value="1"/>
+          <xsd:maxLength value="80"/>
+        </xsd:restriction>
+      </xsd:simpleType>
       <xsd:element name="PosersFault">
         <xsd:complexType>
           <xsd:sequence>

--- a/test/tiny.wsdl
+++ b/test/tiny.wsdl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:s2="http://api.hotbrev.se/FindCounty" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://api.hotbrev.se/" xmlns:s5="http://api.hotbrev.se/LocalityResult" xmlns:s9="http://api.hotbrev.se/ZipCodeResult" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:s6="http://api.hotbrev.se/FindCommunity" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:s10="http://api.hotbrev.se/FindParish" xmlns:s11="http://api.hotbrev.se/ParishResult" xmlns:s3="http://api.hotbrev.se/CountyResult" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:s4="http://api.hotbrev.se/FindLocality" xmlns:s7="http://api.hotbrev.se/CommunityResult" xmlns:s1="http://api.hotbrev.se/FindLove" xmlns:s8="http://api.hotbrev.se/FindZipCode" targetNamespace="http://api.hotbrev.se/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
   <wsdl:types>
     <s:schema elementFormDefault="qualified" targetNamespace="http://api.hotbrev.se/">
@@ -78,6 +78,7 @@
         <s:sequence>
           <s:element minOccurs="0" maxOccurs="1" name="FindName" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="FindSSNo" type="s:string" />
+          <s:element ref="Hemvist" minOccurs="0"/>
         </s:sequence>
         <s:attribute name="Gender" type="s:string" />
         <s:attribute name="Internet" type="s:int" use="required" />
@@ -86,6 +87,14 @@
         <s:attribute name="Vkiid" type="s:int" use="required" />
         <s:attribute name="Vkid" type="s:int" use="required" />
       </s:complexType>
+      <s:element name="Hemvist" type="HemvistTYPE"/>
+      <s:simpleType name="HemvistTYPE">
+        <s:restriction base="xs:string">
+          <s:enumeration value="Skriven på adressen" />
+          <s:enumeration value="På kommunen skriven" />
+          <s:enumeration value="Utan känt hemvist" />
+        </s:restriction>
+      </s:simpleType>
     </s:schema>
   </wsdl:types>
   <wsdl:message name="FindSoapIn">


### PR DESCRIPTION
https://kivra.atlassian.net/browse/UP-1270

This fixes a few things:

1. be able to generate API's that use includes
2. fix bugs relating to 'åäö' in enums
3. fix bug that empty records became undefined and not the empty record.