### PR TITLE
[UP-1603] feat: prefer binaries instead of strings

### DIFF
--- a/src/ews_emit.erl
+++ b/src/ews_emit.erl
@@ -120,7 +120,7 @@ output_single_type(Tn = {_,_}, #meta{max = Max}, _SpecIndent, Tbl,
       " | ").
 
 output_erl_type(string) ->
-    "string() | binary()";
+    "binary() | string()";
 output_erl_type(integer) ->
     "integer()";
 output_erl_type(float) ->

--- a/test/ews_emit_SUITE.erl
+++ b/test/ews_emit_SUITE.erl
@@ -69,7 +69,7 @@ simple_graph(_Config) ->
     ews_emit:model_to_file(Model, Filename, test),
     {ok, Bin} = file:read_file(Filename),
     <<"-record(t1, {e1 :: integer() | undefined,\n"
-      "             e2 :: string() | binary() | nil | undefined}).\n\n">> =
+      "             e2 :: binary() | string() | nil | undefined}).\n\n">> =
         Bin,
     ok.
 


### PR DESCRIPTION
Since we decode to binaries as default, it should probably be first, instead of string. This can later be used by other libraries that parses this union of types and defaults to using the first type in the union. And we all prefer binaries.

The generated files can then be used by `spectra` to encode and decode to json, and now it will decode to binaries since `binary()` comes first in the union of types.
