### PR TITLE
fix: UP-1760 record_to_map crashed on XSD types with XML attributes

### DIFF
--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -102,9 +102,21 @@ record_to_map(Term, M = #model{type_map = Tbl}) ->
     [Alias | Values] = tuple_to_list(Term),
     Parts = ews_model:get_parts(Alias, Tbl),
     FieldNames = field_names(Parts),
-    MapValues = lists:map(fun (V) -> field_to_map(V, M) end, Values),
-    maps:from_list([{K, V} ||  {K, V} <- lists:zip(FieldNames, MapValues),
-                               V /= undefined]).
+    case ews_model:get(Alias, Tbl) of
+        #type{attrs = [_|_]} ->
+            [AttrsVal | ElemValues] = Values,
+            MapValues = lists:map(fun (V) -> field_to_map(V, M) end,
+                                  ElemValues),
+            maps:from_list(
+              [{'__attrs', AttrsVal}
+               | [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),
+                             V /= undefined]]);
+        _ ->
+            MapValues = lists:map(fun (V) -> field_to_map(V, M) end, Values),
+            maps:from_list(
+              [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),
+                          V /= undefined])
+    end.
 %% Internal -------------------------------------------------------------------
 
 %% TODO: handle list of Terms -> check if #meta{max=M}, M > 1
@@ -621,4 +633,7 @@ field_to_map(V, _M) ->
     V.
 
 field_names(Parts) ->
-    [ews_alias:create(QN) || #elem{qname = QN} <- Parts].
+    lists:filtermap(fun(#elem{qname = QN}) -> {true, ews_alias:create(QN)};
+                       (#sc{qname = QN})   -> {true, ews_alias:create(QN)};
+                       (_)                 -> false
+                    end, Parts).

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -107,10 +107,15 @@ record_to_map(Term, M = #model{type_map = Tbl}) ->
             [AttrsVal | ElemValues] = Values,
             MapValues = lists:map(fun (V) -> field_to_map(V, M) end,
                                   ElemValues),
+            AttrsList =
+                case AttrsVal of
+                    undefined -> [];
+                    _ -> [{'__attrs', AttrsVal}]
+                end,
             maps:from_list(
-              [{'__attrs', AttrsVal}
-               | [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),
-                             V /= undefined]]);
+              AttrsList ++
+              [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),
+                          V /= undefined]);
         _ ->
             MapValues = lists:map(fun (V) -> field_to_map(V, M) end, Values),
             maps:from_list(

--- a/src/ews_serialize.erl
+++ b/src/ews_serialize.erl
@@ -116,7 +116,7 @@ record_to_map(Term, M = #model{type_map = Tbl}) ->
               AttrsList ++
               [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),
                           V /= undefined]);
-        _ ->
+        #type{attrs = []} ->
             MapValues = lists:map(fun (V) -> field_to_map(V, M) end, Values),
             maps:from_list(
               [{K, V} || {K, V} <- lists:zip(FieldNames, MapValues),

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -22,6 +22,7 @@
         , test_mm_service/1
         , many_schemas_n_refs/1
         , encode_decode_plain_xsd/1
+        , record_to_map_xsd_with_attrs/1
         ]).
 
 suite() -> [{timetrap, {seconds, 20}}].
@@ -44,6 +45,7 @@ groups() ->
        ]}
     , {xsds,
        [ encode_decode_plain_xsd
+       , record_to_map_xsd_with_attrs
        ]}
     ].
 
@@ -370,6 +372,38 @@ encode_decode_plain_xsd(_Config) ->
     ?assertMatch(NamedType, DecNamed),
     DecUnnamed = ews:decode(xsd_test, EncUnnamed),
     ?assertMatch(Unnamed, DecUnnamed),
+    ok.
+
+%% Regression test: record_to_map must handle types with XML attributes.
+%% Uses real XSD types from xmldsig-core-schema.xsd (loaded via importee.xsd):
+%%   - signature_value_type: simpleContent + attrs (#sc{} in elems)
+%%   - signatures: complexType + attrs (#elem{} in elems)
+record_to_map_xsd_with_attrs(_Config) ->
+    %% Model already loaded by init_per_group(xsds, ...)
+    %% via encode_decode_plain_xsd which calls add_xsd_to_model
+
+    %% signature_value_type is simpleContent with an Id attribute:
+    %%   -record(signature_value_type, {'__attrs', value}).
+    SigVal = {signature_value_type, #{}, <<"dGVzdA==">>},
+    SigValMap = ews:record_to_map(xsd_test, SigVal),
+    ?assert(is_map(SigValMap)),
+    ?assertMatch(#{'__attrs' := #{}, value := <<"dGVzdA==">>}, SigValMap),
+
+    %% Same with an actual attribute value
+    SigVal2 = {signature_value_type, #{'Id' => <<"sig-1">>}, <<"dGVzdA==">>},
+    SigValMap2 = ews:record_to_map(xsd_test, SigVal2),
+    ?assertMatch(#{'__attrs' := #{'Id' := <<"sig-1">>}, value := <<"dGVzdA==">>},
+                 SigValMap2),
+
+    %% signatures is a complexType with child elem + Id attribute:
+    %%   -record(signatures, {'__attrs', signature}).
+    %% We pass undefined for the child to keep it simple.
+    Sigs = {signatures, #{}, undefined},
+    SigsMap = ews:record_to_map(xsd_test, Sigs),
+    ?assert(is_map(SigsMap)),
+    ?assertMatch(#{'__attrs' := #{}}, SigsMap),
+    %% signature child is undefined so should be omitted from map
+    ?assertEqual(false, maps:is_key(signature, SigsMap)),
     ok.
 
 tempfile() ->

--- a/test/ews_wsdl_SUITE.erl
+++ b/test/ews_wsdl_SUITE.erl
@@ -90,6 +90,7 @@ init_per_group(teleadr, Config) ->
     Config;
 init_per_group(xsds, Config) ->
     application:ensure_all_started(ews),
+    ok = ews:add_xsd_to_model(xsd_test, test_wsdl_file("importee.xsd")),
     Config.
 
 end_per_group(google_v201306_campaignService, _Config) ->
@@ -336,8 +337,7 @@ many_schemas_n_refs(_Config) ->
     ok.
 
 encode_decode_plain_xsd(_Config) ->
-    ok = ews:add_xsd_to_model(xsd_test,
-                              test_wsdl_file("importee.xsd")),
+    %% Model loaded by init_per_group(xsds, ...)
     RootMessage =
         {sms_message,
          {header,
@@ -379,8 +379,7 @@ encode_decode_plain_xsd(_Config) ->
 %%   - signature_value_type: simpleContent + attrs (#sc{} in elems)
 %%   - signatures: complexType + attrs (#elem{} in elems)
 record_to_map_xsd_with_attrs(_Config) ->
-    %% Model already loaded by init_per_group(xsds, ...)
-    %% via encode_decode_plain_xsd which calls add_xsd_to_model
+    %% Model loaded by init_per_group(xsds, ...)
 
     %% signature_value_type is simpleContent with an Id attribute:
     %%   -record(signature_value_type, {'__attrs', value}).


### PR DESCRIPTION
record_to_map crashed on XSD types with XML attributes because it didn't skip the __attrs field before zipping field names with values and field_names didn't recognize #sc{} (simpleContent) entries — both causing a lists:zip length mismatch.

```
  {function_clause,
      [{lists,zip,
           [[],[#{},<<"dGVzdA==">>],fail],
           [{file,"lists.erl"},{line,785}]},
       {ews_serialize,record_to_map,2,
           [{file,"ews_serialize.erl"},{line,107}]}
```